### PR TITLE
Bugfix/output encoding

### DIFF
--- a/exe/getinline
+++ b/exe/getinline
@@ -91,7 +91,7 @@ rescue OptionParser::AmbiguousOption => error
   abort "That's an #{error}"
 end
 
-def transform(file_contents, options, premailer_options)
+def transform(file_contents, getinline_options, premailer_options)
   transformer = Getinline::Transformer.new(file_contents, getinline_options, premailer_options)
   puts transformer.transform
 end

--- a/exe/getinline
+++ b/exe/getinline
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'getinline'
 require 'optparse'
 
-options = {
+getinline_options = {
   mode: :html
 }
 premailer_options = {
@@ -14,6 +14,7 @@ premailer_options = {
   remove_classes: false,
   verbose: false,
   line_length: 9001,
+  output_encoding: 'US-ASCII',
   warn_level: Premailer::Warnings::SAFE
 }
 
@@ -30,7 +31,7 @@ option_parser = OptionParser.new do |opts|
   opts.separator 'Options:'
 
   opts.on('--mode MODE', [:html, :txt], 'Output: html or txt') do |v|
-    options[:mode] = v
+    getinline_options[:mode] = v
   end
 
   opts.on('-h', '--help', 'Print usage instructions') do
@@ -69,8 +70,8 @@ option_parser = OptionParser.new do |opts|
     premailer_options[:line_length] = v
   end
 
-  opts.on('-e', '--entities', 'Output HTML entities instead of UTF-8 when using Nokogiri') do
-    premailer_options[:output_encoding] = 'US-ASCII'
+  opts.on('-n', '--no-entities', 'Output UTF-8 instead of HTML entities when using Nokogiri') do
+    premailer_options[:output_encoding] = nil
   end
 
   opts.on('-d', '--io-exceptions', 'Abort on I/O errors') do |v|
@@ -91,12 +92,12 @@ rescue OptionParser::AmbiguousOption => error
 end
 
 def transform(file_contents, options, premailer_options)
-  transformer = Getinline::Transformer.new(file_contents, options, premailer_options)
+  transformer = Getinline::Transformer.new(file_contents, getinline_options, premailer_options)
   puts transformer.transform
 end
 
 if ARGF.filename != '-' || (!STDIN.tty? && !STDIN.closed?)
-  transform(ARGF.read, options, premailer_options)
+  transform(ARGF.read, getinline_options, premailer_options)
 else
   puts option_parser
   exit

--- a/lib/getinline/transformer.rb
+++ b/lib/getinline/transformer.rb
@@ -1,7 +1,7 @@
 require 'premailer'
-require 'nokogiri'
 
 TOKEN = '@TOKEN'
+ERB_TAG = /<%.+?%>/
 TOKENIZED_ERB_FILE_NAME = '/tmp/tokenized.erb'
 
 module Getinline
@@ -13,7 +13,7 @@ module Getinline
     end
 
     def transform
-      matches = @raw_text.scan(/<%.+?%>/)
+      matches = @raw_text.scan(ERB_TAG)
       tokenized_text = @raw_text.dup
       matches.each do |match|
         tokenized_text.sub!(match, TOKEN)
@@ -23,7 +23,7 @@ module Getinline
 
       @premailer = Premailer.new(TOKENIZED_ERB_FILE_NAME, @premailer_options)
       premailed_tokenized_text = @options[:mode] == :txt ?
-        @premailer.to_plain_text : Nokogiri::HTML(@premailer.to_inline_css).to_html(encoding:'US-ASCII')
+        @premailer.to_plain_text : @premailer.to_inline_css
       premailed_text = premailed_tokenized_text.dup
 
       matches.each do |match|

--- a/spec/fixtures/inlined/with-encoded-chars-and-tags.erb
+++ b/spec/fixtures/inlined/with-encoded-chars-and-tags.erb
@@ -1,1 +1,1 @@
-<p style="color: red">That&#8217;s it! <%= @foo %></p>
+<p style="color: red">That&rsquo;s it! <%= @foo %></p>

--- a/spec/fixtures/inlined/with-encoded-chars.erb
+++ b/spec/fixtures/inlined/with-encoded-chars.erb
@@ -1,1 +1,1 @@
-<p style="color: red">&#8217;</p>
+<p style="color: red">&rsquo;</p>


### PR DESCRIPTION
We required Nokogiri to default the HTML entity encoding, this PR replaces that code and uses the premailer option to do the same thing :D
